### PR TITLE
Update Setup to Include Python Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A REST API for facilitating the creation of characters for Wrathskeller.
 - [ ] Trim audio silence
 
 ## Setup
-
+- Install Python 3.18.13
 - Install [Poetry package manager](https://python-poetry.org/docs/)
 - Clone repository `$ git clone git@github.com:Apexal/wrathserver.git`
 - Download dependencies `$ poetry install`

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A REST API for facilitating the creation of characters for Wrathskeller.
 - [ ] Trim audio silence
 
 ## Setup
-- Install Python 3.18.13
+- Install Python 3.8.13
 - Install [Poetry package manager](https://python-poetry.org/docs/)
 - Clone repository `$ git clone git@github.com:Apexal/wrathserver.git`
 - Download dependencies `$ poetry install`


### PR DESCRIPTION
Wrathserver currently requires Python 3.8.13 (according to Poetry). This constraint can be changed in the pyproject.toml file, but for now the version of Python used should be shown.

Additionally, the python version used may want to be changed since it is no longer accessible through an installer and needs to be compiled from source. (This is true through pyenv and python.org)