### PR TITLE
Add FFMPEG requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A REST API for facilitating the creation of characters for Wrathskeller.
 
 ## Setup
 - Install Python 3.8.13
+- Install FFMPEG
 - Install [Poetry package manager](https://python-poetry.org/docs/)
 - Clone repository `$ git clone git@github.com:Apexal/wrathserver.git`
 - Download dependencies `$ poetry install`


### PR DESCRIPTION
FFMPEG is required to process the audio files on the server (at least for MP3). Without it, an error is thrown when an audio file is processed.